### PR TITLE
Adjusted doublespacing further

### DIFF
--- a/misqdoc.cls
+++ b/misqdoc.cls
@@ -22,6 +22,8 @@
 \RequirePackage{fancyhdr}
 % Gotta have that double space
 \RequirePackage[doublespacing]{setspace}
+% Adjust stretch to get results similar to MS Word
+\setstretch{2.2}
 
 % Get rid of spacing inside lists
 \RequirePackage{enumitem}


### PR DESCRIPTION
There is a difference between MS Word and setspace in determining double space.
See here for further discussion:
https://tex.stackexchange.com/questions/13742/what-does-double-spacing-mean

Can be solved with \setstretch{2.2}